### PR TITLE
fixed single value being assignable to Vector2 and Vector3

### DIFF
--- a/include/Math/Vector2.h
+++ b/include/Math/Vector2.h
@@ -59,19 +59,28 @@ namespace astu {
         }
 
         /**
+         * Constructor that implements all components with 0.
+         */
+        explicit Vector2()
+            : Vector2(0, 0)
+        {
+            // Intentionally left empty.
+        }
+
+        /**
          * Constructor.
          * 
          * @param x the x-coordinate of the vector
          * @param y the y-coordinate of the vector
          */
-        Vector2(T x = 0, T y = 0)
+        Vector2(T x, T y)
             : x(x), y(y)
         {
             // Intentionally left empty.
         }
 
         /**
-         * Sets thsi vector to the coordinates of another vector.
+         * Sets this vector to the coordinates of another vector.
          *
          * @param o the other vector which coordinates to use
          * @return reference to this vector for method chaining

--- a/include/Math/Vector3.h
+++ b/include/Math/Vector3.h
@@ -69,13 +69,22 @@ namespace astu {
         }        
 
         /**
+         * Constructor that initializes all components with 0.
+         */
+        Vector3()
+            : Vector3(0, 0, 0)
+        {
+            // intentionally left empty
+        }
+
+        /**
          * Constructor.
          * 
          * @param vx	the x-coordinate
          * @param vy	thy y-coordinate
          * @param vz	thy z-coordinate
          */
-        Vector3(T vx = 0, T vy = 0, T vz = 0)
+        Vector3(T vx, T vy, T vz)
             : x(vx), y(vy), z(vz)
         {
             // intentionally left empty


### PR DESCRIPTION
This change makes the following fail (as seen in a student's submission):
```
Vector2 foo = GetRandomDouble(-5,5);
Vector2 foo(GetRandomDouble(-5,5));
// both result in the following: foo.x = <random value>, foo.y = 0 because y defaults to 0 in the constructor
```
The above should be invalid because it looks like `GetRandomDouble` returns a `Vector2`, which it does not.